### PR TITLE
Update JQL query handling to allow block-level property and add URL encoding

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -106,9 +106,12 @@ async function getJQLResults(useSecondOrg: boolean = false) {
 
     const creds: string = btoa(`${user}:${token}`);
     const authHeader = getAuthHeader(useSecondOrg, token, user, creds, authType);
-    const jqlQuery = `https://${baseURL}/rest/api/${apiVersion}/search?jql=${settings?.jqlQuery}`;
 
-    const response = await axios.get(jqlQuery, {
+    // jql-query property if it exists at block level will override plugin settings.
+    const jqlQuery: string = block?.properties?.jiraJql ?? settings?.jqlQuery ?? '';
+    const jqlQueryURL = `https://${baseURL}/rest/api/${apiVersion}/search?jql=${encodeURIComponent(jqlQuery)}`;
+
+    const response = await axios.get(jqlQueryURL, {
       headers: {
         'Accept': 'application/json',
         'Authorization': authHeader


### PR DESCRIPTION
Small patch to allow a JQL query to be set at block level via a property. It also URLEncodes the JQL Query.

How to use: 

1. Add your query into a block like so:

``` jira-jql:: <YOUR QUERY>```

2. Fetch the results of the query -- navigate to the very top of the block, invoke the existing "/Jira Pull JQL Results" action

(I find this part a bit clunky... it could perhaps be enhanced by adding a clickable button somehow)

3. JQL Results are pulled in:

<img width="755" alt="image" src="https://github.com/user-attachments/assets/ab7b7b1b-ca8f-4d74-b59f-2225c510273f" />



